### PR TITLE
feat(ui): center Framework components with flex layout

### DIFF
--- a/src/components/Framework.astro
+++ b/src/components/Framework.astro
@@ -1,12 +1,16 @@
 ---
 const {image, alt, label, href} = Astro.props
 ---
-<a href={href}>
-    <article class="cursor-pointer py-8 px-28  m-auto flex flex-col gap-5 framework bg-slate-950 rounded-2xl max-sm:w-full max-md:w-full">
-        <img src={image} alt={alt} class="frameworks-img m-auto w-6/12 max-xl:w-10/12 flex items-center justify-center max-sm:w-1/2 " >
-        <label class="text-center flex m-auto justify-center items-center text-gray-400 ">{label}</label>
+<div class="flex justify-center">
+    <a href={href}
+    class="w-full" 
+    >
+    <article class="framework cursor-pointer py-8 flex flex-col bg-slate-950 rounded-2xl">
+        <img src={image} alt={alt} class="frameworks-img pb-5 h-24"  >
+        <label class="text-center text-gray-400 ">{label}</label>
     </article>
 </a>
+</div>
 
 <style>
 .framework{

--- a/src/components/Framework.astro
+++ b/src/components/Framework.astro
@@ -6,7 +6,7 @@ const {image, alt, label, href} = Astro.props
     class="w-full" 
     >
     <article class="framework cursor-pointer py-8 flex flex-col bg-slate-950 rounded-2xl">
-        <img src={image} alt={alt} class="frameworks-img pb-5 h-24"  >
+        <img src={image} alt={alt} class="frameworks-img py-5 h-24"  >
         <label class="text-center text-gray-400 ">{label}</label>
     </article>
 </a>

--- a/src/sections/Frameworks.astro
+++ b/src/sections/Frameworks.astro
@@ -3,12 +3,12 @@ import Framework from "../components/Framework.astro";
 
 
 ---
-<section class="py-20 px-8  gradient-section " id="framework">
-  <div class="max-w-7xl m-auto"> 
+<section class="py-20 px-8 gradient-section " id="framework">
+  <div class="max-w-7xl mx-auto"> 
 
     <h2 class="text-white text-center text-5xl">Frameworks</h2>
     <p class="text-gray-400 text-center text-xl mt-5">NicoUI es compatible con todos los principales frameworks del desarrollo frontend.</p>
-    <div class="grid grid-cols-3 justify-center items-center mt-14 gap-8 max-md:grid-cols-2 max-sm:grid-cols-1">
+    <div class="mt-14 gap-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
       <Framework
         image="/Angular.svg"
         alt="Angular svg"


### PR DESCRIPTION
- Add flex justify-center to Framework container
- Ensure consistent horizontal centering of framework cards
- Maintain responsive grid layout while preserving centered alignment

Before 
![Screenshot 2024-11-22 154049](https://github.com/user-attachments/assets/e77aa362-a5cf-4d59-91ee-f664aeeccc96)
![Screenshot 2024-11-22 162343](https://github.com/user-attachments/assets/19787012-46ee-4afd-905f-36e30e3a0665)

After
![Screenshot 2024-11-22 154105](https://github.com/user-attachments/assets/8416cb6c-4695-489a-9612-32f879998400)
![Screenshot 2024-11-22 162351](https://github.com/user-attachments/assets/6b3fcd29-8f8f-4c7e-ace4-302a84b9ec4d)

